### PR TITLE
Added ordering to tunnel apis and also added ReqOptions

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -502,8 +502,10 @@ func (api *API) Raw(ctx context.Context, method, endpoint string, data interface
 // PaginationOptions can be passed to a list request to configure paging
 // These values will be defaulted if omitted, and PerPage has min/max limits set by resource.
 type PaginationOptions struct {
-	Page    int `json:"page,omitempty" url:"page,omitempty"`
-	PerPage int `json:"per_page,omitempty" url:"per_page,omitempty"`
+	Page      int    `json:"page,omitempty" url:"page,omitempty"`
+	PerPage   int    `json:"per_page,omitempty" url:"per_page,omitempty"`
+	Order     string `json:"order,omitempty" url:"order,omitempty"`
+	Direction string `json:"direction,omitempty" url:"direction,omitempty"`
 }
 
 // RetryPolicy specifies number of retries and min/max retry delays
@@ -553,6 +555,14 @@ func WithPagination(opts PaginationOptions) ReqOption {
 
 		if opts.PerPage > 0 {
 			opt.params.Set("per_page", strconv.Itoa(opts.PerPage))
+		}
+
+		if len(opts.Order) > 0 {
+			opt.params.Set("order", opts.Order)
+		}
+
+		if len(opts.Direction) > 0 {
+			opt.params.Set("direction", opts.Direction)
 		}
 	}
 }

--- a/testdata/fixtures/tunnel/ordered_full.json
+++ b/testdata/fixtures/tunnel/ordered_full.json
@@ -1,0 +1,17 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {
+      "id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+      "name": "tunnel-1",
+      "created_at": "2009-11-10T23:00:00Z"
+    },
+    {
+      "id": "f0bacd1c-566a-4203-a157-0b69222b2b5b",
+      "name": "tunnel-2",
+      "created_at": "2009-11-10T23:00:00Z"
+    }
+  ]
+}

--- a/tunnel.go
+++ b/tunnel.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/google/go-querystring/query"
 	"net/http"
 	"time"
 )
@@ -176,9 +177,18 @@ type TunnelListParams struct {
 // Tunnels lists all tunnels.
 //
 // API reference: https://api.cloudflare.com/#cloudflare-tunnel-list-cloudflare-tunnels
-func (api *API) Tunnels(ctx context.Context, rc *ResourceContainer, params TunnelListParams) ([]Tunnel, error) {
+func (api *API) Tunnels(ctx context.Context, rc *ResourceContainer, params TunnelListParams, opts ...ReqOption) ([]Tunnel, error) {
 	if rc.Identifier == "" {
 		return []Tunnel{}, ErrMissingAccountID
+	}
+
+	v, _ := query.Values(params)
+	opt := reqOption{
+		params: v,
+	}
+
+	for _, of := range opts {
+		of(&opt)
 	}
 
 	uri := buildURI(fmt.Sprintf("/accounts/%s/cfd_tunnel", rc.Identifier), params)

--- a/tunnel.go
+++ b/tunnel.go
@@ -193,6 +193,9 @@ func (api *API) Tunnels(ctx context.Context, rc *ResourceContainer, params Tunne
 
 	uri := buildURI(fmt.Sprintf("/accounts/%s/cfd_tunnel", rc.Identifier), params)
 
+	if len(opt.params) > 0 {
+		uri = uri + "?" + opt.params.Encode()
+	}
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
 		return []Tunnel{}, err

--- a/tunnel.go
+++ b/tunnel.go
@@ -191,7 +191,7 @@ func (api *API) Tunnels(ctx context.Context, rc *ResourceContainer, params Tunne
 		of(&opt)
 	}
 
-	uri := buildURI(fmt.Sprintf("/accounts/%s/cfd_tunnel", rc.Identifier), params)
+	uri := buildURI(fmt.Sprintf("/accounts/%s/cfd_tunnel", rc.Identifier), opt)
 
 	if len(opt.params) > 0 {
 		uri = uri + "?" + opt.params.Encode()

--- a/tunnel_test.go
+++ b/tunnel_test.go
@@ -79,8 +79,11 @@ func TestTunnelOrdering(t *testing.T) {
 		Order:     "name",
 		Direction: "asc",
 	})
+	valTrue := true
 	actual, err := client.Tunnels(context.Background(), AccountIdentifier(testAccountID),
-		TunnelListParams{}, paginationOption)
+		TunnelListParams{
+			IsDeleted: &valTrue,
+		}, paginationOption)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)


### PR DESCRIPTION
## Description

List Tunnels golang client  doesn't support ordering by and order direction though from the REST API does support though its not mentioned in the documentation

Eg : 
https://api.cloudflare.com/client/v4/accounts/accountid/cfd_tunnel?direction=asc&order=name&page=1&per_page=100

This PR adds support to order the tunnels by an ordering key like name or status,
And the direction of ordering , asc or desc.


## Has your change been tested?

Added a unit test and also conducted an integration test by calling the cloudflare api and noticing the ordering difference with new changes

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
